### PR TITLE
Threadpools/ Mulithreading Support and Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
         run: |
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j
+          ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,5 +4,15 @@ project(kvstore LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_executable(kv_server src/server.cpp)
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
+)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(kv_tests tests/kv_tests.cpp src/kv_store.cpp src/ThreadPool.cpp)
+target_link_libraries(kv_tests gtest_main)
+
+add_executable(kv_server src/kv_store.cpp src/ThreadPool.cpp)
 add_executable(kv_client src/client.cpp)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Key-Value Store
-Multithreaded Key-Value Store v0.1
+Multithreaded Key-Value Store v1.0
 
-Currently supports a singlethreaded key-value store using a STL unordered_map.
+Currently implemented using a STL unordered_map. Mulithreading is enabled using mutex locks and a pool of threads.
 
 ## Build & Run
 ```bash

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,5 +1,5 @@
 
-# Key-Value Store v0.1 Protocol
+# Key-Value Store v1.0 Protocol
 
 ASCII Commands:
 SET <key> <val>

--- a/src/ThreadPool.cpp
+++ b/src/ThreadPool.cpp
@@ -1,0 +1,36 @@
+#include "ThreadPool.hpp"
+
+ThreadPool::ThreadPool(size_t thread_count) {
+    for (size_t i = 0; i < thread_count; ++i) {
+        workers.emplace_back([this] {
+            while (true) {
+                std::function<void()> task;
+                {
+                    std::unique_lock lock(m);
+                    cv.wait(lock, [&]{ return stop || !tasks.empty(); });
+                    if (stop && tasks.empty()) return;
+                    task = std::move(tasks.front());
+                    tasks.pop();
+                }
+                task();
+            }
+        });
+    }
+}
+
+ThreadPool::~ThreadPool() {
+    {
+        std::lock_guard lock(m);
+        stop = true;
+    }
+    cv.notify_all();
+    for (auto& w : workers) w.join();
+}
+
+void ThreadPool::enqueue(const std::function<void()>& f) {
+    {
+        std::lock_guard lock(m);
+        tasks.emplace(std::move(f));
+    }
+    cv.notify_one();
+}

--- a/src/ThreadPool.hpp
+++ b/src/ThreadPool.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <queue>
+#include <thread>
+#include <vector>
+#include <condition_variable>
+#include <functional>
+
+class ThreadPool {
+public:
+    ThreadPool(size_t thread_count = std::thread::hardware_concurrency());
+    ~ThreadPool();
+    void enqueue(const std::function<void()>& f);
+
+private:
+    std::vector<std::thread> workers;
+    std::queue<std::function<void()>> tasks;
+    std::mutex m;
+    std::condition_variable cv;
+    bool stop{false};
+};

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/socket.h>

--- a/src/kv_store.hpp
+++ b/src/kv_store.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <atomic>
+
+extern int server_fd;
+extern std::atomic<bool> running;
+extern std::unordered_map<std::string, std::string> map;
+extern std::mutex m;
+
+void sigint_handler(int);
+int open_listen_socket(const std::string& port);
+void handle_client(int client_fd);

--- a/tests/kv_tests.cpp
+++ b/tests/kv_tests.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+#include "../src/kv_store.hpp"
+#include <thread>
+#include <netdb.h>
+#include <signal.h>
+
+TEST(KVStore, SingleThreadSetGetDel) {
+    std::lock_guard<std::mutex> lock(m);
+    map.clear();
+    map["Hello"] = "World!";
+    ASSERT_EQ(map["Hello"], "World!");
+    map.erase("Hello");
+    ASSERT_EQ(map.count("Hello"), 0);
+}
+
+TEST(KVStore, ConcurrencyTest) {
+    {
+        std::lock_guard<std::mutex> lock(m);
+        map.clear();
+    }
+    
+    const int n = 10000;
+    auto insert_function = [](int thread_id) {
+        for (int i = 0; i < n; ++i) {
+            std::string k = "k" + std::to_string(thread_id * n + i);
+            std::string v = "v" + std::to_string(i);
+            {
+                std::lock_guard<std::mutex> lock(m);
+                map[k] = v;
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    const int thread_count = 8;
+    for (int i = 0; i < thread_count; ++i) {
+        threads.emplace_back(insert_function, i);
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(m);
+        ASSERT_EQ(map.size(), thread_count * n);
+    }
+}
+
+bool server_running(const std::string& host, const std::string& port) {
+    addrinfo hints{}, *res;
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    if (getaddrinfo(host.c_str(), port.c_str(), &hints, &res) != 0) return false;
+
+    const int n = 100;
+    for (int i = 0; i < n; ++i) {
+        int fd = socket(res->ai_family, res->ai_socktype, 0);
+        if (fd < 0) {
+            freeaddrinfo(res);
+            return false;
+        }
+        if(!connect(fd, res->ai_addr, res->ai_addrlen)) {
+            close(fd);
+            freeaddrinfo(res);
+            return true;
+        }
+        close(fd);
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    freeaddrinfo(res);
+    return false;
+}
+
+std::string client_get(const std::string& host, const std::string& port, const std::string& key) {
+    int pipe_fd[2];
+    if (pipe(pipe_fd) != 0) {
+        return "Pipe Error";
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        return "Fork Error";
+    }
+
+    if (pid == 0) {
+        dup2(pipe_fd[1], STDOUT_FILENO);
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        execl("./kv_client", host.c_str(), port.c_str(), "GET", key.c_str(), nullptr);
+        exit(1);
+    }
+
+    close(pipe_fd[1]);
+    std::string client_output;
+    char buf[256];
+    ssize_t bytes_read = read(pipe_fd[0], buf, sizeof(buf));
+    while (bytes_read > 0) {
+        client_output.append(buf, bytes_read);
+        bytes_read = read(pipe_fd[0], buf, sizeof(buf));
+    }
+
+    close(pipe_fd[0]);
+    int status;
+    waitpid(pid, &status, 0);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        return "Client failed";
+    }
+
+    return client_output;
+}
+
+void kill_server(pid_t pid) {
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+}
+
+TEST(KVStore, IntegrationTest) {
+    std::string host = "127.0.0.1";
+    std::string port = std::to_string(67876);
+    
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0) << "Fork error";
+
+    if (pid == 0) {
+        execl("./kv_server", "kv_server", port.c_str(), nullptr);
+        exit(1);
+    }
+
+    if(!server_running(host, port)) {
+        kill_server(pid);
+        FAIL() << "Server error";
+    }
+
+    std::string client_call = "./kv_client " + host + " " + port;
+    if(system((client_call + " SET Hello World!").c_str()) != 0) {
+        kill_server(pid);
+        FAIL() << "SET failed";
+    }
+    
+    std::string client_output = client_get(host, port, "Hello");
+    if(client_output != "$World!\n") {
+        kill_server(pid);
+        FAIL() << "GET failed with output: " << client_output;
+    }
+
+    if(system((client_call + " DEL Hello").c_str()) != 0) {
+        kill_server(pid);
+        FAIL() << "DEL failed";
+    }
+
+    client_output = client_get(host, port, "Hello");
+    if(client_output != "NULL!\n") {
+        kill_server(pid);
+        FAIL() << "GET after DEL failed with output: " << client_output;
+    }
+
+    kill(pid, SIGINT);
+    int status;
+    waitpid(pid, &status, 0);
+    ASSERT_TRUE(WIFEXITED(status));
+}


### PR DESCRIPTION
Utilized threadpools to allow for multithreaded use of the hashmap in the KV Store. Added single-threaded, multi-threaded, and integration tests.